### PR TITLE
Refine workflow

### DIFF
--- a/.github/workflows/nfssext-autochecks.yml
+++ b/.github/workflows/nfssext-autochecks.yml
@@ -65,9 +65,6 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout repo
         uses: actions/checkout@v4
-      # https://github.com/josephwright/siunitx/blob/549cad913591b92a3a199b7477a325866303bf29/.github/workflows/main.yaml
-      # We need Ghostscript for XeTeX tests.
-      - run: sudo apt-get update #&& sudo apt-get install ghostscript 
       # Steps represent a sequence of tasks that will be executed as part of the job
       - name: Restore TeX Live from cache
         uses: actions/cache/restore@v4
@@ -204,11 +201,12 @@ jobs:
         uses: actions/checkout@v4
       # https://github.com/josephwright/siunitx/blob/549cad913591b92a3a199b7477a325866303bf29/.github/workflows/main.yaml
       # We need Ghostscript for XeTeX tests.
-      - name: Update system 
-        run: sudo apt-get update
       - name: Install additional packages if needed
         if: ${{ matrix.extra_packages }}
-        run: sudo apt-get install ${{ matrix.extra_packages }}
+        uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: ${{ matrix.extra_packages }}
+          version: 1.0
       - name: Restore TeX Live from cache
         uses: actions/cache/restore@v4
         with:
@@ -320,11 +318,12 @@ jobs:
         uses: actions/checkout@v4
       # https://github.com/josephwright/siunitx/blob/549cad913591b92a3a199b7477a325866303bf29/.github/workflows/main.yaml
       # We need Ghostscript for XeTeX tests.
-      - name: Update system 
-        run: sudo apt-get update
       - name: Install additional packages if needed
         if: ${{ matrix.extra_packages }}
-        run: sudo apt-get install ${{ matrix.extra_packages }}
+        uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: ${{ matrix.extra_packages }}
+          version: 1.0
       - name: Restore TeX Live from cache
         uses: actions/cache/restore@v4
         with:

--- a/.github/workflows/nfssext-autochecks.yml
+++ b/.github/workflows/nfssext-autochecks.yml
@@ -7,11 +7,8 @@ name: Automatic Checks for nfssext
 
 # Controls when the workflow will run
 on:
-  # Triggers the workflow on push or pull request events but only for the "main" branch
   push:
     branches: 
-      # - "*"
-      # - "*workflow"
       - '*'
     paths:
       - '**'

--- a/.github/workflows/nfssext-autochecks.yml
+++ b/.github/workflows/nfssext-autochecks.yml
@@ -66,11 +66,10 @@ jobs:
         uses: actions/checkout@v4
       # Steps represent a sequence of tasks that will be executed as part of the job
       - name: Restore TeX Live from cache
-        uses: actions/cache/restore@v4
-        with: 
-          path: ~/texlive
-          key: ${{ needs.texlive-cache.outputs.cache_key }}
-          fail-on-cache-miss: true
+        # This step re-uses the cache generated at "texlive-cache"
+        uses: zauguin/install-texlive@v3
+        with:
+          package_file: .github/tl_packages
       # oes angen hwn?
       # oes!
       - name: Set PATH
@@ -207,11 +206,10 @@ jobs:
           packages: ${{ matrix.extra_packages }}
           version: 1.0
       - name: Restore TeX Live from cache
-        uses: actions/cache/restore@v4
+        # This step re-uses the cache generated at "texlive-cache"
+        uses: zauguin/install-texlive@v3
         with:
-          path: ~/texlive
-          key: ${{ needs.texlive-cache.outputs.cache_key }}
-          fail-on-cache-miss: true
+          package_file: .github/tl_packages
         # oes angen hwn?
         # oes!
       - name: Set PATH

--- a/.github/workflows/nfssext-autochecks.yml
+++ b/.github/workflows/nfssext-autochecks.yml
@@ -60,11 +60,11 @@ jobs:
     # cfr-lm uses nfssext-cfr but there's nothing to build
     # outputs:
     #   clm_cache_key: $(( steps.clm-cache.outputs.cache_key }}
+    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout repo
         uses: actions/checkout@v4
-      # Steps represent a sequence of tasks that will be executed as part of the job
       - name: Restore TeX Live from cache
         # This step re-uses the cache generated at "texlive-cache"
         uses: zauguin/install-texlive@v3

--- a/.github/workflows/nfssext-autochecks.yml
+++ b/.github/workflows/nfssext-autochecks.yml
@@ -18,6 +18,8 @@ on:
       - '.github/workflows/nfssext-autochecks.yml'
       - '!licences/**'
       - '!test/**'
+    tags:
+      - '*'
   pull_request:
     branches: 
       - "*"

--- a/.github/workflows/nfssext-release.yml
+++ b/.github/workflows/nfssext-release.yml
@@ -8,7 +8,6 @@ name: Build release for  nfssext
 
 # Controls when the workflow will run
 on:
-  # Triggers the workflow on push or pull request events but only for the "main" branch
   push:
     tags: 
       - '*'


### PR DESCRIPTION
This refines the workflow:

- Runs checks also on a tag build - this should ensure that there is no "real" broken release
- Cache installed packages (by using https://github.com/awalsh128/cache-apt-pkgs-action?tab=readme-ov-file#cache-apt-pkgs-action) -- to speed up build
- Use [install-texlive](https://github.com/zauguin/install-texlive)'s capabilities to cache - no more internal cache handling.
- Removes wrog workflow comments